### PR TITLE
Added json demarshalling of historic visits/views data and bar chart displaying that views data

### DIFF
--- a/ui.go
+++ b/ui.go
@@ -58,7 +58,7 @@ func (stat Stat) String() string {
 }
 
 // InitUIElements populate initial state of ui
-func InitUIElements(safeSiteData SafeSiteData, siteList *widgets.List, selectedBox *widgets.Paragraph) {
+func InitUIElements(safeSiteData *SafeSiteData, siteList *widgets.List, selectedBox *widgets.Paragraph) {
 	titleBox := widgets.NewParagraph()
 	titleBox.Title = "WordPresser"
 	titleBox.Text = "Press up/down keys to scroll list, esc to exit."
@@ -85,7 +85,7 @@ func InitUIElements(safeSiteData SafeSiteData, siteList *widgets.List, selectedB
 }
 
 // ListenForKeyboardEvents handle keyboard events
-func ListenForKeyboardEvents(safeSiteData SafeSiteData, siteList *widgets.List, selectedBox *widgets.Paragraph) {
+func ListenForKeyboardEvents(safeSiteData *SafeSiteData, siteList *widgets.List, selectedBox *widgets.Paragraph) {
 	uiEvents := ui.PollEvents()
 	for {
 		e := <-uiEvents

--- a/wpr.go
+++ b/wpr.go
@@ -17,10 +17,10 @@ import (
 )
 
 // Sites represents all user sites.
-// TODO: Add visits struct for graphing: https://github.com/gizak/termui
 type Sites struct {
-	Date  string `json:"date"`
-	Stats Stat   `json:"stats"`
+	Date  	string 	`json:"date"`
+	Stats 	Stat   	`json:"stats"`
+	Visits 	Visit	`json:"visits"`
 }
 
 // Stat object for a given site.
@@ -29,6 +29,10 @@ type Stat struct {
 	VisitorsYesterday int `json:"visitors_yesterday"`
 	ViewsToday        int `json:"views_today"`
 	ViewsYesterday    int `json:"views_yesterday"`
+}
+
+type Visit struct {
+	Data [][3]interface{} `json:"data"`
 }
 
 // Global list of sites
@@ -160,7 +164,7 @@ func getSites(http_client *http.Client, request *http.Request, token string) (*A
 }
 
 
-func lookupSiteStats(http_client *http.Client, token string, site Site, safeSiteData SafeSiteData, siteList *widgets.List, selectedBox *widgets.Paragraph) {
+func lookupSiteStats(http_client *http.Client, token string, site Site, safeSiteData *SafeSiteData, siteList *widgets.List, selectedBox *widgets.Paragraph) {
 	// fetch site stats from rest api
 	stats, err := getStats(fmt.Sprint(site.ID), http_client, token)
 
@@ -217,13 +221,13 @@ func main() {
 			safeSiteData.setSiteData(currentSite.URL, "Fetching Data for "+currentSite.URL)
 		}
 
-		InitUIElements(safeSiteData, siteList, selectedBox)
+		InitUIElements(&safeSiteData, siteList, selectedBox)
 
 		for _, site := range allSites.Sites {
-			go lookupSiteStats(http_client, token, site, safeSiteData, siteList, selectedBox)
+			go lookupSiteStats(http_client, token, site, &safeSiteData, siteList, selectedBox)
 		}
 
-		ListenForKeyboardEvents(safeSiteData, siteList, selectedBox)
+		ListenForKeyboardEvents(&safeSiteData, siteList, selectedBox)
 
 	}
 }


### PR DESCRIPTION
There's an issue with TermUI where if the barchart data is set to an array of all zeros it gets a oom error. I've worked around it by checking that the array isn't all zeros before setting. 

I'm rendering the views data, as I thought that was more interesting than the visitor data.

Let me know if there's any changes you'd like to make to the ui, and how it renders on mac, might be a bit different from windows.